### PR TITLE
CTECH-1903: Pins version of lusid-sdk-preview to <= 1.0

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -5,5 +5,5 @@ setuptools >= 21.0.0
 urllib3 >= 1.26.9
 pytz >= 2019.1
 requests >= 2.27.1
-lusid-sdk-preview>=0.11.4699
+lusid-sdk-preview >= 0.11.4699, <= 1.0
 lusidfeature

--- a/src/setup.py
+++ b/src/setup.py
@@ -37,7 +37,7 @@ REQUIRES = [
     "requests >= 2.27.1",
     "six >= 1.10",
     "urllib3 >= 1.26.9",
-    "lusid-sdk-preview >= 0.11.*"
+    "lusid-sdk-preview >= 0.11.*, <= 1.0"
 ]
 
 version = {}


### PR DESCRIPTION
Signed-off-by: Paul Saunders <paul.saunders@finbourne.com>

# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass

# Description of the PR

Upcoming changes to the the generator for the sdk's might break compatibility.  This pins the version of the lusid sdk so that this package will not break in such an event.
