### PR TITLE
CTECH-1903: Pins version of sdks < 2.

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -5,5 +5,5 @@ setuptools >= 21.0.0
 urllib3 >= 1.26.9
 pytz >= 2019.1
 requests >= 2.27.1
-lusid-sdk-preview >= 0.11.4699, <= 1.0
+lusid-sdk-preview >= 0.11.4699, < 2
 lusidfeature


### PR DESCRIPTION
Signed-off-by: Paul Saunders <paul.saunders@finbourne.com>

# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass

# Description of the PR

Upcoming changes to the the generator for the sdk's might break compatibility. This pins the version of the finbourne sdks so that this package will not break in such an event.

The premise previously had been that pinning to <= 1.0 would still allow us to update patch versions 1.0.x however that is not true, so now pinning < 2